### PR TITLE
Added support for padding of element while taking screenshot

### DIFF
--- a/spec/rectangle_spec.rb
+++ b/spec/rectangle_spec.rb
@@ -1,7 +1,17 @@
 require_relative '../lib/screenshot.rb'
 
 # Rectangle is defined as set of co-ordinates represented by top left x, top left y, width, height
+# Iframe Offset rectangle will always have width and height to be 0, because these parameters
+# are not required for finding the correct cropped rectangle
 describe 'Rectangle' do
+  it 'should return the co-ordinates of the rectangle with given offset' do
+    input_rectangle = [0, 0, 1, 1]
+    input_rectangles = [input_rectangle]
+    offset_rectangle = [1, 1, 2, 2]
+    output_rectangle = [1, 1, 3, 3]
+    expect(Screenshot.rectangle(input_rectangles, offset_rectangle)).to eq(output_rectangle)
+  end
+
   it 'should return the co-ordinates of provided 1 rectangle' do
     input_rectangle = [0, 0, 1, 1]
     input_rectangles = [input_rectangle]
@@ -10,10 +20,10 @@ describe 'Rectangle' do
 
   it 'should return the co-ordinates of the rectangle which is inside a iframe' do
     input_rectangle  = [50, 50, 10, 10]
-    iframe_rectangle = [100, 100, 20, 20]
+    iframe_offset_rectangle = [100, 100, 0, 0]
     input_rectangles = [input_rectangle]
     output_rectangle = [150, 150, 10, 10]
-    expect(Screenshot.rectangle(input_rectangles, iframe_rectangle)).to eq(output_rectangle)
+    expect(Screenshot.rectangle(input_rectangles, iframe_offset_rectangle)).to eq(output_rectangle)
   end
 
   it 'if we provide 2 rectangles and if one contains the other then it should return co-ordinates of bigger rectangle' do


### PR DESCRIPTION
- capture method has another optional argument called offset
  which can either be a page object iframe element or a rectangle
- Rectangle co-ordinates(x, y, width, height) will be directly
  appended to the final screenshot rectangle.
- Page object iframe element's x and y co-ordinates will be summed
  with final screenshot rectangles respective co-ordinates to get the
  required screenshot
- Hence the iframe element's rectangle co-ordinates can be [x, y, 0, 0] as
  width and height are not useful

Bug: T87786
